### PR TITLE
PhotoOrg: Adding support to send logging from server to renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "photoorganizer",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "electron-log": "^5.4.3"
+      },
       "devDependencies": {
         "electron": "^37.3.1",
         "typescript": "^5.4.5"
@@ -303,6 +306,15 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/end-of-stream": {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "devDependencies": {
     "electron": "^37.3.1",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "electron-log": "^5.4.3"
   }
 }

--- a/preload.ts
+++ b/preload.ts
@@ -3,5 +3,13 @@ import { contextBridge, ipcRenderer } from 'electron';
 // expose only the file open dir read block
 contextBridge.exposeInMainWorld('electronAPI', {
     // the renderer will call this function which will securely send a message to the main process of electron
-    selectFolder: () => ipcRenderer.invoke('dialog:openDirectory')
+    selectFolder: () => ipcRenderer.invoke('dialog:openDirectory'),
+    handleLogMessage: (callback: (msg: {message: string, level: string}) => void ) => {
+        ipcRenderer.on(
+            'send-to-frontend-channel', (_event, msg) => {
+                console.log("inside the preload script handleLogMessage function");
+                callback(msg);
+            }
+        );
+    }
 });

--- a/renderer.ts
+++ b/renderer.ts
@@ -1,6 +1,8 @@
 
 interface ElectronAPI {
     selectFolder: () => Promise<string | null>;
+    // function exposed from the server to send log message from server to frontend
+    handleLogMessage: (callback: (msg: {message: string, level: string}) => void ) => void;
 }
 
 declare global {
@@ -25,6 +27,16 @@ if (selectFolderBtn && logsDiv) {
             logsDiv.innerHTML += 'Folder selection was cancelled.<br/>';
         }
     });
+}
+
+
+// now lets add the logs from the server to the div 
+if (logsDiv) {
+    console.log("found logsDiv so adding a callback to the handleLogMessage function")
+    window.electronAPI.handleLogMessage((msg) => {
+        console.log('inside the callback function now got message: ($msg)');
+        logsDiv.innerHTML += `from server: ${msg.message}<br/>`;
+    })
 }
 
 // This makes the file a module and fixes the "declare global" error.


### PR DESCRIPTION
1. the idea here is to send the logs form the server to the renderer.
2. so when the server is trying to go over the photos we can send the logging information to the users to they can see what is the server doing under the hood.
3. This should also help in the tshooting problems