### PR TITLE
using segregator to group images and videos by year

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
     <button id="select-folder-button"> Select Folder</button>
     <h3>Photo Organizer logs</h3>
     <div id="photo-organizer-logs"></div>
+    <h3>Photo Organizer Proposal</h3>
+    <div id="photo-organizer-proposal"> </div> 
     <script type="module" src="./dist/renderer/renderer.js"></script>
   </body>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,11 @@ module.exports = {
       tsconfig: 'tsconfig.main.json',  // make sure ts-jest reads your config
     },
   },
+  testMatch: [
+    "__tests__/**/*.(spec|test).ts",
+    "**/?(*.)+(spec|test).ts"
+  ],
+  modulePathIgnorePatterns: [
+    "/dist/",
+  ],
 };

--- a/main.ts
+++ b/main.ts
@@ -9,7 +9,7 @@ import { MediaFilesHandler } from "./lib/process_folder";
  * and loads the index.html file
  */
 class PhotoOrganizer {
-    private window!: BrowserWindow;
+    window!: BrowserWindow;
     logger!: ChannelLogger;
     private readonly logger_channel: string;
 
@@ -65,7 +65,9 @@ class StartPhotoOrganizer {
 
             console.log("app is ready so creating window");
             this.photoOrganizer.init();
-            const mediaFilesHandler = new MediaFilesHandler(this.photoOrganizer.logger);
+            const mediaFilesHandler = new MediaFilesHandler(
+                this.photoOrganizer.logger, this.photoOrganizer.window
+            );
             ipcMain.handle('dialog:openDirectory', mediaFilesHandler.handleFolderOpen);
         })
     }

--- a/preload.ts
+++ b/preload.ts
@@ -6,9 +6,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     selectFolder: () => ipcRenderer.invoke('dialog:openDirectory'),
     // handleLogMessage just receives the message onthe ipcRenderer on the 
     // send-to-frontend-channel and calls the callback function
-    handleLogMessage: (callback: (msg: {message: string, level: string}) => void ) => {
+    handleLogMessage: (callback: (msg: { message: string, level: string }) => void) => {
         ipcRenderer.on(
             'send-to-frontend-channel', (_event, msg) => {
+                callback(msg);
+            }
+        );
+    },
+    showProposal: (callback: (proposal: string) => void) => {
+        ipcRenderer.on(
+            'proposal-channel', (_event, msg) => {
                 callback(msg);
             }
         );

--- a/renderer/renderer.ts
+++ b/renderer/renderer.ts
@@ -2,7 +2,9 @@
 interface ElectronAPI {
     selectFolder: () => Promise<string | null>;
     // function exposed from the server to send log message from server to frontend
-    handleLogMessage: (callback: (msg: {message: string, level: string}) => void ) => void;
+    handleLogMessage: (callback: (msg: { message: string, level: string }) => void) => void;
+    // show proposal 
+    showProposal: (callback: (proposal: string) => void) => void;
 }
 
 declare global {
@@ -13,6 +15,8 @@ declare global {
 
 const selectFolderBtn = document.getElementById('select-folder-button');
 const logsDiv = document.getElementById('photo-organizer-logs');
+const proposalDiv = document.getElementById('photo-organizer-proposal');
+
 
 // It's best practice to ensure the elements exist before adding listeners.
 // This also satisfies TypeScript's null-check.
@@ -39,5 +43,21 @@ if (logsDiv) {
     })
 }
 
+
+
+if (proposalDiv) {
+
+    window.electronAPI.showProposal((proposalJSON) => {
+        console.log(`inside the callback function now got message: ${proposalJSON}`);
+        const proposal = JSON.parse(proposalJSON);
+        let html = "<ul>";
+        for (const year in proposal) {
+            html += `<li><b>${year}</b>: ${proposal[year].join(', ')}</li>`;
+        }
+        html += "</ul>";
+        proposalDiv.innerHTML += `Proposal:<br/>${html}`;
+    });
+}
+
 // This makes the file a module and fixes the "declare global" error.
-export {};
+export { };


### PR DESCRIPTION
1. adding the segregator logic to group videos and photos
2. sending BrowserWindow to MediaFileHandler so that we can send a grouped message back to the frontend
3. created a new diff in the frontend so that we can show group proposal
4. using the ctime instead of birthtime as birthtime is most of the time epoch time.

/gemini review 